### PR TITLE
Update tests and dependencies for mlipflow restructuring

### DIFF
--- a/mlipflow/strategies/dft.py
+++ b/mlipflow/strategies/dft.py
@@ -46,12 +46,13 @@ class EMTCalc(QChemStrategy):
         super().__init__()
         self.remote_info = None
 
-    def get_calculator(self, job_name: str) -> tuple:
+    def get_calculator(self, job_name: str, **kwargs) -> tuple:
         """
         Get the EMT calculator.
 
         Args:
             job_name (str): Name of the job (unused).
+            **kwargs: Additional arguments to match QECalculator signature.
 
         Returns:
             tuple: (EMT class, None, dict with options)

--- a/tests/test_dft_strategy.py
+++ b/tests/test_dft_strategy.py
@@ -1,0 +1,128 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from mlipflow.strategies.dft import EMTCalc, QECalculator
+from ase.calculators.emt import EMT
+from wfl.calculators.espresso import Espresso
+
+def test_emt_calc_get_calculator():
+    strategy = EMTCalc()
+    calc_class, args, kwargs = strategy.get_calculator(job_name="test")
+    assert calc_class == EMT
+    assert args is None
+    assert kwargs == {"fixed_cutoff": True}
+    assert strategy.remote_info is None
+
+def test_qe_calculator_init(tmp_path):
+    # Create dummy basic params file
+    params_file = tmp_path / "basic_params.json"
+    params_content = {
+        "control": {
+            "nstep": 100,
+            "etot_conv_thr": 1e-4,
+            "forc_conv_thr": 1e-3,
+            "dipfield": True,
+            "tefield": True
+        },
+        "system": {
+            "eamp": 0.0,
+            "edir": 1,
+            "emaxpos": 0.5,
+            "eopreg": 0.1,
+            "dftd3_version": 3,
+            "vdw_corr": "dft-d3"
+        },
+        "electrons": {}
+    }
+    import json
+    params_file.write_text(json.dumps(params_content))
+
+    pseudo_dir = tmp_path / "pseudo"
+    pseudo_dir.mkdir()
+
+    strategy = QECalculator(basic_params=str(params_file), pseudo_dir=str(pseudo_dir))
+    assert strategy.basic_params == str(params_file)
+    assert strategy.pseudo_dir == str(pseudo_dir)
+    assert strategy.qe_prefix == 'DFT_'
+
+@patch('mlipflow.strategies.dft.prepare_remote')
+def test_qe_calculator_get_calculator(mock_prepare_remote, tmp_path):
+    # Setup
+    params_file = tmp_path / "basic_params.json"
+    params_content = {
+        "control": {
+            "nstep": 100,
+            "etot_conv_thr": 1e-4,
+            "forc_conv_thr": 1e-3,
+            "dipfield": True,
+            "tefield": True
+        },
+        "system": {
+            "eamp": 0.0,
+            "edir": 1,
+            "emaxpos": 0.5,
+            "eopreg": 0.1,
+            "dftd3_version": 3,
+            "vdw_corr": "dft-d3"
+        },
+        "electrons": {}
+    }
+    import json
+    params_file.write_text(json.dumps(params_content))
+    pseudo_dir = tmp_path / "pseudo"
+    pseudo_dir.mkdir()
+
+    strategy = QECalculator(basic_params=str(params_file), pseudo_dir=str(pseudo_dir))
+    mock_prepare_remote.return_value = MagicMock()
+
+    # Test scf
+    calc_class, args, kwargs = strategy.get_calculator(job_name="test_job", calc_type="scf")
+
+    assert calc_class == Espresso
+    assert strategy.remote_info is not None
+    assert kwargs['rundir_prefix'] == 'QE_'
+    assert kwargs['input_data']['control']['calculation'] == 'scf'
+    assert kwargs['input_data']['system']['ecutwfc'] == 64.97 # Based on default logic
+
+    # Check remote settings
+    mock_prepare_remote.assert_called()
+    call_kwargs = mock_prepare_remote.call_args[1]
+    assert call_kwargs['max_time'] == '01:25:00'
+    assert call_kwargs['job_name'] == 'test_job'
+
+@patch('mlipflow.strategies.dft.prepare_remote')
+def test_qe_calculator_get_calculator_relax(mock_prepare_remote, tmp_path):
+    # Setup
+    params_file = tmp_path / "basic_params.json"
+    params_content = {
+        "control": {
+            "nstep": 100,
+            "etot_conv_thr": 1e-4,
+            "forc_conv_thr": 1e-3,
+            "dipfield": True,
+            "tefield": True
+        },
+        "system": {
+            "eamp": 0.0,
+            "edir": 1,
+            "emaxpos": 0.5,
+            "eopreg": 0.1,
+            "dftd3_version": 3,
+            "vdw_corr": "dft-d3"
+        },
+        "electrons": {}
+    }
+    import json
+    params_file.write_text(json.dumps(params_content))
+    pseudo_dir = tmp_path / "pseudo"
+    pseudo_dir.mkdir()
+
+    strategy = QECalculator(basic_params=str(params_file), pseudo_dir=str(pseudo_dir))
+
+    # Test relax
+    strategy.get_calculator(job_name="test_job_relax", calc_type="relax")
+
+    # Check remote settings for relax
+    call_kwargs = mock_prepare_remote.call_args[1]
+    assert call_kwargs['max_time'] == '06:25:00'
+    assert call_kwargs['n_cores'] == 32

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,26 +1,31 @@
 import os
+import shutil
 import pytest
-from unittest.mock import MagicMock, patch
-from mlipflow.graphflow.nodes import run_dft_sp, EnsembleState
-from mlipflow.strategies.dft import QChemStrategy
+from unittest.mock import MagicMock
+from mlipflow.graphflow.nodes import run_dft_sp, assess_n_select, EnsembleState
+from mlipflow.strategies.dft import EMTCalc
 from mlipflow.graphflow.graphs import execute_dft_single_point_block
-
-class MockQChemStrategy(QChemStrategy):
-    def __init__(self):
-        super().__init__()
-        self.qe_prefix = 'DFT_'
-        self.remote_info = None
-
-    def get_calculator(self, job_name, **kwargs):
-        return (MagicMock(), [], {})
+from ase.io import read, write
 
 @pytest.fixture
-def mock_state(tmp_path):
-    config_file = tmp_path / "test_config.xyz"
-    with open(config_file, 'w') as f:
-        f.write("dummy")
+def real_data_setup(tmp_path):
+    """
+    Setup fixture that copies real data to a temporary directory.
+    Returns the path to the config file and the state.
+    """
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    src_xyz = os.path.join(test_dir, 'data', 'test_data.xyz')
 
-    qchem_strategy = MockQChemStrategy()
+    # We need a model file for MACE strategy even if we mock the strategy itself
+    # just to pass some checks if any. But here we primarily test DFT part.
+
+    config_file = tmp_path / "test_data.xyz"
+    shutil.copy2(src_xyz, config_file)
+
+    # Setup strategies
+    qchem_strategy = EMTCalc()
+
+    # Mock MLIP strategy just to provide the prefix
     mlip_strategy = MagicMock()
     mlip_strategy.mlip_prefix = 'MACE_'
 
@@ -29,34 +34,104 @@ def mock_state(tmp_path):
         qchem_strategy=qchem_strategy,
         mlip_strategy=mlip_strategy
     )
-    return state
+    return state, tmp_path
 
-def test_run_dft_sp(mock_state):
-    with patch('mlipflow.graphflow.nodes.run_single_point') as mock_run:
-        new_state = run_dft_sp(mock_state)
+def test_run_dft_sp_with_emt(real_data_setup):
+    """
+    Test run_dft_sp using EMTCalc and real data.
+    This verifies that run_single_point actually works with the strategy and data.
+    """
+    state, tmp_path = real_data_setup
 
-        assert len(new_state['configs']) == 1
-        assert new_state['configs'][0].endswith('.dft.xyz')
-        mock_run.assert_called_once()
+    # Execute the node
+    new_state = run_dft_sp(state)
 
-        # Verify call arguments
-        args, kwargs = mock_run.call_args
-        assert kwargs['in_file'] == mock_state['configs']
-        assert kwargs['output_prefix'] == 'DFT_'
+    # Verify output file exists
+    output_file = new_state['configs'][0]
+    assert os.path.exists(output_file)
+    assert output_file.endswith('.dft.xyz')
 
-def test_execute_dft_single_point_block(mock_state):
-    # We need to mock nodes because we don't want to run actual DFT or selection
-    with patch('mlipflow.graphflow.nodes.run_single_point') as mock_run_sp:
-        # We also need to mock assess_n_select because it relies on files existing and content
-        with patch('mlipflow.graphflow.nodes.split_configset_by_force_agreement') as mock_split:
+    # Verify content
+    atoms = read(output_file, ':')
+    assert len(atoms) > 0
+    # Check if results are present. EMTCalc uses "DFT_" prefix in QChemStrategy?
+    # No, EMTCalc inherits QChemStrategy which sets qe_prefix = 'DFT_'
+    # generic_calc with output_prefix='DFT_' should store results in info/arrays with that prefix.
+    # For 'energy', it should be 'DFT_energy'.
 
-            app = execute_dft_single_point_block()
-            final_state = app.invoke(mock_state)
+    # EMT calculator might write 'energy' directly to atoms.calc.results,
+    # but generic_calc + output_prefix handles the storage.
+    # Let's check info keys
+    assert 'DFT_energy' in atoms[0].info
+    assert 'DFT_forces' in atoms[0].arrays
 
-            # verify flow
-            mock_run_sp.assert_called()
-            mock_split.assert_called()
+def test_execute_dft_single_point_block_integration(real_data_setup):
+    """
+    Test the full DFT block execution with EMTCalc.
+    Flow: dft_sp -> assess_n_select
+    """
+    state, tmp_path = real_data_setup
 
-            # assess_n_select sets configs=['train_dft.xyz'], outfile=['test_dft.xyz']
-            assert final_state['configs'] == ['train_dft.xyz']
-            assert final_state['outfile'] == ['test_dft.xyz']
+    # We need to ensure that the data has MACE_forces for assess_n_select to work,
+    # as split_configset_by_force_agreement compares DFT_forces and MACE_forces.
+    # Since we are not running MACE here, we can manually add dummy MACE forces to the input file
+    # OR we can update the input file before running the graph.
+
+    # Let's update the input file with dummy MACE forces.
+    atoms = read(state['configs'][0], ':')
+    import numpy as np
+    for at in atoms:
+        at.arrays['MACE_forces'] = np.random.random((len(at), 3))
+    write(state['configs'][0], atoms)
+
+    # Initialize graph
+    app = execute_dft_single_point_block()
+
+    # Run graph
+    final_state = app.invoke(state)
+
+    # Check results
+    # assess_n_select should produce 'train_dft.xyz' and 'test_dft.xyz' (prefixed/suffixed)
+    # The node assess_n_select hardcodes output file name to 'dft.xyz'
+    # and split_configset_by_force_agreement writes to {suffix}_{out_file}.
+    # So we expect 'train_dft.xyz' and 'test_dft.xyz' in the CWD?
+    # Wait, where does it write?
+
+    # In assess_n_select:
+    # out_file='dft.xyz'
+    # split_configset_by_force_agreement(..., out_file='dft.xyz', ...)
+
+    # If run in tmp_path context, it should be fine.
+    # But graph execution might not respect tmp_path if not explicitly handled.
+    # The state['configs'] are absolute paths from tmp_path.
+    # But 'dft.xyz' is relative.
+
+    # We should run this test changing cwd to tmp_path to capture outputs
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        final_state = app.invoke(state)
+
+        assert 'configs' in final_state
+        assert 'outfile' in final_state
+
+        train_file = final_state['configs'][0] # Should be train_dft.xyz
+        test_file = final_state['outfile'][0] # Should be test_dft.xyz
+
+        assert os.path.exists(train_file)
+        assert os.path.exists(test_file)
+
+        # Verify filenames
+        assert 'train_dft.xyz' in train_file
+        assert 'test_dft.xyz' in test_file
+
+        # Verify split happened
+        train_atoms = read(train_file, ':')
+        test_atoms = read(test_file, ':')
+
+        assert len(train_atoms) > 0
+        assert len(test_atoms) > 0
+        assert len(train_atoms) + len(test_atoms) == len(atoms)
+
+    finally:
+        os.chdir(cwd)

--- a/tests/test_wfl_adapter.py
+++ b/tests/test_wfl_adapter.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+from ase import Atoms
+from unittest.mock import MagicMock
+from mlipflow.adapters.wflio import ForceCheck, select_config
+
+def test_force_check():
+    abort = ForceCheck(threshold=1.0, n_failed_steps=2)
+
+    # Mock atoms with calculator
+    at = Atoms('H')
+    calc = MagicMock()
+    at.calc = calc
+
+    # Case 1: Forces below threshold
+    calc.get_forces.return_value = np.array([[0.5, 0.0, 0.0]])
+    assert bool(abort.atoms_ok(at)) is True
+
+    # Case 2: Forces above threshold
+    calc.get_forces.return_value = np.array([[1.5, 0.0, 0.0]])
+    assert bool(abort.atoms_ok(at)) is False
+
+def test_select_config():
+    # Helper to create list of dummy objects
+    traj = [i for i in range(20)]
+
+    # Case < 10
+    short_traj = traj[:5]
+    assert select_config(short_traj) == [4]
+
+    # Case == 500
+    long_traj = [i for i in range(500)]
+    assert select_config(long_traj) == [499]
+
+    # Case else (e.g. 20)
+    assert select_config(traj) == [10]


### PR DESCRIPTION
- Updated imports in `tests/test_core.py`, `tests/test_mace_strategy.py`, `tests/test_structure_generator.py`.
- Deleted obsolete `tests/test_active_learner.py`.
- Added new unit tests `tests/test_data_processing.py`, `tests/test_data_selection.py`, `tests/test_dft_strategy.py`, `tests/test_wfl_adapter.py`.
- Added integration tests `tests/test_integration.py` for graphflow, using real data and `EMTCalc`.
- Updated `mlipflow/data/__init__.py` to export `clean_up` and `merge_clean_chunks`.
- Fixed `mlipflow/core/relaxation_fire.py` to correctly check for convergence.
- Modified `mlipflow/strategies/dft.py` to allow flexible arguments in `EMTCalc`.
- Downgraded `mace-torch` to 0.3.12 to resolve compatibility issues.
- Updated `MACEModel` usage in tests (use `mlip_name`).
- Ensured tests use temporary directories for output.
- Added `torch-dftd` and `langgraph` to `pyproject.toml` to fix CI failures.