### PR TITLE
Refactor tests (EMT) and add configuration selection test

### DIFF
--- a/mlipflow/data/selector.py
+++ b/mlipflow/data/selector.py
@@ -66,6 +66,11 @@ class ConfigurationSelector:
             map_func=self._get_average_desc,
             args=[self.desc_key]
         )
+        if not write_xyz:
+            # Force realization to list to allow multiple passes
+            # We store it as a list because ConfigSet might be single-pass
+            self.global_desc = list(self.global_desc)
+
         return self.global_desc
 
     def _ensure_descriptors_calculated(self):
@@ -176,6 +181,7 @@ class ConfigurationSelector:
                 similarity_row = at_descs[:, selected_indices[-1]].T @ at_descs
                 similarity_row[exclude_ind_list] = max_similarity
                 similarities_arr = np.vstack([similarities_arr, similarity_row])
+                similarities_arr[:, selected_indices[-1]] = max_similarity
 
         write_selected_and_clean(inputs, outputs, selected_indices, at_descs_info_key, keep_descriptor_info)
 

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import MagicMock
 from ase.io import read
 from ase.constraints import FixAtoms
-from ase.calculators.lj import LennardJones
+from ase.calculators.emt import EMT
 from mlipflow.graphflow.nodes import EnsembleState
 from mlipflow.graphflow.graphs import execute_initial_basin_pathsampling_md_block
 from mlipflow.strategies.mlip import MACEModel
@@ -14,8 +14,7 @@ from mlipflow.strategies.dft import EMTCalc
 def test_execute_initial_basin_pathsampling_md_block(tmp_path):
     """
     Test execute_initial_basin_pathsampling_md_block with MACE and MDGen.
-    We mock MACE calculator with LennardJones to avoid version compatibility issues
-    and element support issues (EMT doesn't support C/H/O).
+    We mock MACE calculator with EMT to ensure compatibility.
     """
     # Setup paths
     test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -38,12 +37,12 @@ def test_execute_initial_basin_pathsampling_md_block(tmp_path):
         # We don't need the actual model file if we mock get_calculator
         mlip_strategy = MACEModel(mlip_name="mace_test", run_mode="local")
 
-        # Mock get_calculator to return LennardJones calculator
+        # Mock get_calculator to return EMT calculator
         # The signature of get_calculator is (job_name, dispersion=True, ...)
-        # We return (LennardJones, [], kwargs) so wfl uses LennardJones(**kwargs)
+        # We return (EMT, [], kwargs) so wfl uses EMT(**kwargs)
         mlip_strategy.remote_info = None
-        # Use generic parameters for LJ
-        mlip_strategy.get_calculator = MagicMock(return_value=(LennardJones, [], {'sigma': 2.0, 'epsilon': 1.0}))
+        # Use generic parameters for EMT
+        mlip_strategy.get_calculator = MagicMock(return_value=(EMT, [], {}))
 
         # MDGen with minimal steps
         structure_gen_strategy = MDGen(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -87,9 +87,6 @@ def test_execute_dft_single_point_block_integration(real_data_setup):
     # Initialize graph
     app = execute_dft_single_point_block()
 
-    # Run graph
-    final_state = app.invoke(state)
-
     # Check results
     # assess_n_select should produce 'train_dft.xyz' and 'test_dft.xyz' (prefixed/suffixed)
     # The node assess_n_select hardcodes output file name to 'dft.xyz'

--- a/tests/test_nodes_selection.py
+++ b/tests/test_nodes_selection.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+import pytest
+import numpy as np
+from unittest.mock import MagicMock
+from ase.io import read, write
+from mlipflow.graphflow.nodes import run_configuration_selection, EnsembleState
+
+def test_run_configuration_selection(tmp_path):
+    """
+    Test run_configuration_selection using real data and dummy info fields.
+    """
+    # Setup paths
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    src_xyz = os.path.join(test_dir, 'data', 'test_data.xyz')
+    config_file = tmp_path / "test_data.xyz"
+    shutil.copy2(src_xyz, config_file)
+
+    # Add dummy energy info to the configurations
+    atoms = read(config_file, ':')
+    rng = np.random.default_rng(42)
+    new_atoms_list = []
+    for at in atoms:
+        # Filter to keep only Cu atoms to avoid descriptor mismatch with simple Z=29 descriptor
+        # The wfl/quippy wrapper expects descriptor arrays to match atom count if applied globally
+        at = at[at.numbers == 29]
+        at.info['dummy_energy'] = rng.random()
+        new_atoms_list.append(at)
+    write(config_file, new_atoms_list)
+
+    # Change directory to tmp_path to capture outputs
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Setup EnsembleState
+        # Valid descriptors for Cu (Z=29)
+        descriptor_string = "soap cutoff=4.0 l_max=4 n_max=4 atom_sigma=0.5 n_Z=1 Z={29} n_species=1 species_Z={29}"
+
+        calculation_kwargs = {
+            'selection': {
+                'descriptor_string': descriptor_string,
+                'descriptor_key': 'SOAP',
+                'info_field': 'dummy_energy',
+                'n_optimal': 5,
+                'seed': 42
+            }
+        }
+
+        # Mock strategies as they are required keys in EnsembleState TypedDict
+        qchem_mock = MagicMock()
+        mlip_mock = MagicMock()
+
+        state = EnsembleState(
+            configs=[str(config_file)],
+            qchem_strategy=qchem_mock,
+            mlip_strategy=mlip_mock,
+            calculation_kwargs=calculation_kwargs
+        )
+
+        # Run selection
+        result = run_configuration_selection(state)
+
+        # Verify output
+        output_configs = result['configs']
+        assert len(output_configs) == 1
+        output_file = output_configs[0]
+
+        assert os.path.exists(output_file)
+
+        # Verify content
+        selected_atoms = read(output_file, ':')
+        assert len(selected_atoms) == 5
+
+        # Verify descriptors are present (ConfigurationSelector adds them)
+        assert 'SOAP' in selected_atoms[0].info
+
+    finally:
+        os.chdir(cwd)

--- a/tests/test_structure_generator.py
+++ b/tests/test_structure_generator.py
@@ -1,6 +1,6 @@
 import os, pytest
 from unittest.mock import MagicMock
-from ase.calculators.lj import LennardJones
+from ase.calculators.emt import EMT
 from mlipflow.strategies.structure_generators import OPTGen
 from mlipflow.strategies.mlip import MACEModel
 
@@ -13,8 +13,8 @@ def test_optgen_run(tmp_path):
         run_mode="local"
     )
 
-    # Mock get_calculator to return LennardJones calculator to avoid MACE execution errors
-    mace.get_calculator = MagicMock(return_value=(LennardJones, [], {'sigma': 2.0, 'epsilon': 1.0}))
+    # Mock get_calculator to return EMT calculator to avoid MACE execution errors
+    mace.get_calculator = MagicMock(return_value=(EMT, [], {}))
     mace.remote_info = None
 
     out_file = tmp_path / 'opt_test.xyz'


### PR DESCRIPTION
This PR addresses the request to add a test for `run_configuration_selection` and refactor existing tests.

Changes:
1.  **New Test:** Added `tests/test_nodes_selection.py` which uses `tests/data/test_data.xyz` to verify the configuration selection workflow. It creates dummy energy data and checks if the correct number of configurations are selected.
2.  **Refactoring:** Modified `tests/test_graphs.py` and `tests/test_structure_generator.py` to use `ase.calculators.emt.EMT` instead of `LennardJones`. This ensures better compatibility with the Cu dataset and avoids potential issues with LJ not supporting certain elements or having different parameter requirements.
3.  **Bug Fixes:**
    *   In `mlipflow/data/selector.py`, force realization of `self.global_desc` to a list when `write_xyz=False`. This prevents iterator exhaustion when multiple selection methods (CUR, Histogram) iterate over the same ConfigSet.
    *   In `greedy_fps_with_tracking`, added a missing update to `similarities_arr` to mask the newly selected index, preventing duplicate selection in the memory-efficient path.
4.  **Test Hygiene:** Updated `tests/test_integration.py` to ensure `app.invoke(state)` is only called within the `os.chdir(tmp_path)` block, preventing output files (`train_dft.xyz`, `test_dft.xyz`) from being written to the repository root.

Verification:
- All tests in `tests/` passed (`python -m pytest tests/`).
- Confirmed no files are left in the project root after test execution.

---
*PR created automatically by Jules for task [5578225196314793119](https://jules.google.com/task/5578225196314793119) started by @Vespertili0*