### PR TITLE
Fix tests and update generator parameters

### DIFF
--- a/mlipflow/graphflow/nodes.py
+++ b/mlipflow/graphflow/nodes.py
@@ -320,8 +320,10 @@ def _run_structure_generation_logic(
     mlip = state['mlip_strategy']
     structure_generator = state['structure_gen_strategy']
     
+    # Set default structure generation parameters
+    sg_params = structure_generator.params.copy()
     if structure_gen_params_override:
-        sg_params = {**structure_generator.params, **structure_gen_params_override}
+        sg_params.update(structure_gen_params_override)
 
 
     calc_type = getattr(structure_generator, 'calc_prefix', 'opt')

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -4,7 +4,6 @@ import pytest
 from unittest.mock import MagicMock
 from ase.io import read
 from ase.constraints import FixAtoms
-from ase.calculators.emt import EMT
 from mlipflow.graphflow.nodes import EnsembleState
 from mlipflow.graphflow.graphs import execute_initial_basin_pathsampling_md_block
 from mlipflow.strategies.mlip import MACEModel
@@ -14,7 +13,7 @@ from mlipflow.strategies.dft import EMTCalc
 def test_execute_initial_basin_pathsampling_md_block(tmp_path):
     """
     Test execute_initial_basin_pathsampling_md_block with MACE and MDGen.
-    We mock MACE calculator with EMT to ensure compatibility.
+    We mock MACE calculator with EMTCalc to ensure compatibility.
     """
     # Setup paths
     test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -42,13 +41,14 @@ def test_execute_initial_basin_pathsampling_md_block(tmp_path):
         # We return (EMT, [], kwargs) so wfl uses EMT(**kwargs)
         mlip_strategy.remote_info = None
         # Use generic parameters for EMT
-        mlip_strategy.get_calculator = MagicMock(return_value=(EMT, [], {}))
+        # Use EMTCalc().get_calculator for the mock side_effect to match the return signature
+        mlip_strategy.get_calculator = MagicMock(side_effect=EMTCalc().get_calculator)
 
         # MDGen with minimal steps
         structure_gen_strategy = MDGen(
             uncertainty_thrs=float('inf'), # Infinite threshold to ensure MD runs even with bad random structures
             n_failed_steps=2,
-            md_params={'steps': 5, 'dt': 1.0, 'temperature': 300.0, 'traj_step_interval': 1}
+            params={'steps': 5, 'dt': 1.0, 'temperature': 300.0, 'traj_step_interval': 1}
         )
 
         # QChem strategy (dummy)
@@ -75,7 +75,12 @@ def test_execute_initial_basin_pathsampling_md_block(tmp_path):
                 }
             },
             'mlip_gen': {'dispersion': False}, # Disable dispersion to avoid dftd3 dependency issues if any
-            'mlip_sp': {'dispersion': False}
+            'mlip_sp': {'dispersion': False},
+            'selection': {
+                'descriptor_string': 'soap n_species=4 species_Z={1 6 8 29} l_max=6 n_max=8 cutoff=3.5 atom_sigma=0.5 zeta=6',
+                'info_field': 'MACE_energy',
+                'n_optimal': 5
+            }
         }
 
         state = EnsembleState(
@@ -98,7 +103,7 @@ def test_execute_initial_basin_pathsampling_md_block(tmp_path):
         # Check files
         for f in result['configs']:
             assert os.path.exists(f)
-            assert f.endswith('.mace.xyz')
+            assert f.endswith('final_selection.xyz')
 
             atoms = read(f, ':')
             assert len(atoms) > 0

--- a/tests/test_neb_pairing.py
+++ b/tests/test_neb_pairing.py
@@ -53,7 +53,7 @@ def test_neb_pairing_and_opt(test_data_setup):
         
         # Run OPTGen on resulting structures
         # Use traj_subselect=None to keep full trajectory even if unconverged
-        opt_gen = OPTGen(opt_params=opt_params, traj_subselect=None)
+        opt_gen = OPTGen(params=opt_params, traj_subselect=None)
         
         # Iterate over results (ConfigSets)
         for i, config_set in enumerate(results):

--- a/tests/test_structure_generator.py
+++ b/tests/test_structure_generator.py
@@ -1,6 +1,6 @@
 import os, pytest
 from unittest.mock import MagicMock
-from ase.calculators.emt import EMT
+from mlipflow.strategies.dft import EMTCalc
 from mlipflow.strategies.structure_generators import OPTGen
 from mlipflow.strategies.mlip import MACEModel
 
@@ -14,12 +14,12 @@ def test_optgen_run(tmp_path):
     )
 
     # Mock get_calculator to return EMT calculator to avoid MACE execution errors
-    mace.get_calculator = MagicMock(return_value=(EMT, [], {}))
+    mace.get_calculator = MagicMock(side_effect=EMTCalc().get_calculator)
     mace.remote_info = None
 
     out_file = tmp_path / 'opt_test.xyz'
     # Use traj_subselect=None to ensure output is written even if not converged
-    OPTGen(opt_params={'fmax': 5.0, 'steps': 2}, traj_subselect=None).generate_new_structures(
+    OPTGen(params={'fmax': 5.0, 'steps': 2}, traj_subselect=None).generate_new_structures(
         in_file=in_file,
         out_file=str(out_file),
         calculator=mace.get_calculator(


### PR DESCRIPTION
This PR fixes the failing tests by aligning them with the current codebase structure. 
Specifically:
1.  **Parameter Renaming**: Updates `MDGen` and `OPTGen` usage in tests to use the generic `params` argument instead of deprecated `md_params` or `opt_params`.
2.  **Calculator Replacement**: Replaces direct usage of `ase.calculators.emt.EMT` with `mlipflow.strategies.dft.EMTCalc` in tests, ensuring the tests use the project's defined DFT strategy interface.
3.  **Bug Fix**: Fixes a `UnboundLocalError` (or similar) in `mlipflow/graphflow/nodes.py` where `sg_params` was used without initialization when no override was provided.
4.  **Test Configuration**: Updates `tests/test_graphs.py` to provide necessary `selection` parameters (including `descriptor_string` and `info_field`) required by the updated graph workflow, and corrects the expected output filename assertion.

---
*PR created automatically by Jules for task [8356225392950695192](https://jules.google.com/task/8356225392950695192) started by @Vespertili0*