### PR TITLE
Fix test failures involving ConfigSet length and test data cleanup

### DIFF
--- a/mlipflow/data/semi_supervised_gmm.py
+++ b/mlipflow/data/semi_supervised_gmm.py
@@ -73,8 +73,8 @@ class GMMLabelChecker:
         pca_threshold: float = 0.95,
         gmm_iters: int = 100,
     ):
-        self.train_configs = atoms_to_list(ConfigSet(train_file))
-        self.pool_configs = atoms_to_list(ConfigSet(pool_file))
+        self.train_configs = list(ConfigSet(train_file))
+        self.pool_configs = list(ConfigSet(pool_file))
         self.mlip_strategy = mlip_strategy
         self.calc = MACECalculator(model_paths=self.mlip_strategy.model_file, device=device)
         self.device = device

--- a/tests/test_semi_supervised_gmm.py
+++ b/tests/test_semi_supervised_gmm.py
@@ -43,7 +43,4 @@ def test_semi_supervised_gmm_pipeline():
             assert 'gmm_certainty' in config.info
             
     finally:
-        if os.path.exists(train_file):
-            os.remove(train_file)
-        if os.path.exists(pool_file):
-            os.remove(pool_file)
+        pass


### PR DESCRIPTION
This commit fixes two failing tests that occurred in `test_semi_supervised_gmm_pipeline` and `test_optgen_run`:

1.  **TypeError in `GMMLabelChecker`**: The input paths were loaded using `atoms_to_list(ConfigSet(...))`, but this returned a `ConfigSet` object which doesn't support the `__len__` method needed for the log message in `_step3_high_certainty_filter`. This has been updated to use `list(ConfigSet(...))` directly, which correctly instantiates a Python list that supports `len()` and the downstream processes.
2.  **Missing Test Data (`test_data.xyz`)**: In `tests/test_semi_supervised_gmm.py`, the `test_semi_supervised_gmm_pipeline` test erroneously included a `finally` block that deleted `test_data.xyz` and `test_data_II.xyz` from the static `tests/data` directory. This subsequently broke the `test_optgen_run` test which relies on `test_data.xyz`. The deletion logic has been removed to preserve these source data files.

All 22 tests are now passing again.

---
*PR created automatically by Jules for task [760016527308646379](https://jules.google.com/task/760016527308646379) started by @Vespertili0*